### PR TITLE
Feature/rust edition maintenance

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,11 @@
-# List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
+
 tasks:
   - name: Cargo
     init: |
       cargo fetch
       cargo build
+
+vscode:
+  extensions:
+    - rust-lang.rust
+    - tamasfe.even-better-toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rocket_async_compression"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 description = "Response compression in both gzip and brotli formats for the Rocket webserver using the async-compression library"
 license = "MIT"
@@ -13,4 +13,8 @@ rocket = "0.5.0-rc.1"
 lazy_static = "1.4.0"
 futures = "0.3.17"
 
-async-compression = { version = "0.3.8", features = ["gzip", "brotli", "tokio"] }
+async-compression = { version = "0.3.8", features = [
+    "gzip",
+    "brotli",
+    "tokio",
+] }

--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -47,13 +47,13 @@ lazy_static! {
 ///
 /// use rocket_async_compression::Compression;
 ///
-/// fn main() {
-///     rocket::build()
-///         // ...
-///         .attach(Compression::fairing())
-///         // ...
+///
+/// rocket::build()
+///     // ...
+///     .attach(Compression::fairing())
+///     // ...
 ///     # ;
-/// }
+///
 /// ```
 pub struct Compression(());
 
@@ -68,13 +68,11 @@ impl Compression {
     ///
     /// use rocket_async_compression::Compression;
     ///
-    /// fn main() {
-    ///     rocket::build()
-    ///         // ...
-    ///         .attach(Compression::fairing())
-    ///         // ...
+    /// rocket::build()
+    ///     // ...
+    ///     .attach(Compression::fairing())
+    ///     // ...
     ///     # ;
-    /// }
     /// ```
     pub fn fairing() -> Compression {
         Compression(())

--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -48,7 +48,7 @@ lazy_static! {
 /// use rocket_async_compression::Compression;
 ///
 /// fn main() {
-///     rocket::ignite()
+///     rocket::build()
 ///         // ...
 ///         .attach(Compression::fairing())
 ///         // ...
@@ -69,7 +69,7 @@ impl Compression {
     /// use rocket_async_compression::Compression;
     ///
     /// fn main() {
-    ///     rocket::ignite()
+    ///     rocket::build()
     ///         // ...
     ///         .attach(Compression::fairing())
     ///         // ...


### PR DESCRIPTION
A bit of maintenance:
 - updating to rust 2021
 - following some clippy suggestions
 - Making the docs examples work again (as they act as tests too)
 - formatting Cargo.toml with better toml
 - Adding some rust extensions for gitpod