### PR TITLE
Add CachedCompression fairing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["rocket", "gzip", "brotli", "compression"]
 rocket = "0.5.0-rc.2"
 lazy_static = "1.4.0"
 futures = "0.3.17"
+tokio = { version = "1.20.0" }
 
 async-compression = { version = "0.3.8", features = [
     "gzip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["rocket", "gzip", "brotli", "compression"]
 rocket = "0.5.0-rc.2"
 lazy_static = "1.4.0"
 futures = "0.3.17"
-tokio = { version = "1.20.0" }
 
 async-compression = { version = "0.3.8", features = [
     "gzip",

--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -13,9 +13,6 @@ lazy_static! {
         MediaType::parse_flexible("application/wasm").unwrap(),
         MediaType::parse_flexible("application/octet-stream").unwrap(),
     ];
-    static ref CACHED_PATH_ENDINGS: Vec<&'static str> = vec![
-        ".otf", "main.dart.js"
-    ];
     static ref CACHED_FILES: Mutex<HashMap<(String, bool, bool), (Vec<u8>, String)>> = {
         let m = HashMap::new();
         Mutex::new(m)

--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -1,6 +1,8 @@
 use lazy_static::lazy_static;
 use rocket::fairing::{Fairing, Info, Kind};
 use rocket::{http::MediaType, Request, Response};
+use tokio::io::AsyncReadExt;
+use std::{collections::HashMap, sync::Mutex, io::Cursor};
 
 lazy_static! {
     static ref EXCLUSIONS: Vec<MediaType> = vec![
@@ -11,6 +13,13 @@ lazy_static! {
         MediaType::parse_flexible("application/wasm").unwrap(),
         MediaType::parse_flexible("application/octet-stream").unwrap(),
     ];
+    static ref CACHED_PATH_ENDINGS: Vec<&'static str> = vec![
+        ".otf", "main.dart.js"
+    ];
+    static ref CACHED_FILES: Mutex<HashMap<(String, bool, bool), (Vec<u8>, String)>> = {
+        let m = HashMap::new();
+        Mutex::new(m)
+    };
 }
 
 /// Compresses all responses with Brotli or Gzip compression.
@@ -90,5 +99,112 @@ impl Fairing for Compression {
 
     async fn on_response<'r>(&self, request: &'r Request<'_>, response: &mut Response<'r>) {
         super::CompressionUtils::compress_response(request, response, &EXCLUSIONS);
+    }
+}
+
+/// Compresses all responses with Brotli or Gzip compression. Caches compressed
+/// response bodies in memory for selected file types/path suffixes, useful for
+/// compressing large compiled JS/CSS files, OTF font packs, etc.
+///
+/// Compression is done in the same manner as the [`Compress`](super::Compress)
+/// responder.
+///
+/// By default, the fairing does not compress responses with a `Content-Type`
+/// matching any of the following:
+///
+/// - `application/gzip`
+/// - `application/zip`
+/// - `image/*`
+/// - `video/*`
+/// - `application/wasm`
+/// - `application/octet-stream`
+///
+/// The excluded types can be changed changing the `compress.exclude` Rocket
+/// configuration property in Rocket.toml. The default `Content-Type` exclusions
+/// will be ignored if this is set, and must be added back in one by one if
+/// desired.
+///
+/// ```toml
+/// [global.compress]
+/// exclude = ["video/*", "application/x-xz"]
+/// ```
+///
+/// # Usage
+///
+/// Attach the compression [fairing](/rocket/fairing/) to your Rocket
+/// application:
+///
+/// ```rust
+///
+/// use rocket_async_compression::CachedCompression;
+///
+///
+/// rocket::build()
+///     // ...
+///     .attach(CachedCompression::fairing(vec![".otf", "main.dart.js"]))
+///     // ...
+///     # ;
+///
+/// ```
+pub struct CachedCompression {
+    pub cached_path_endings: Vec<&'static str>
+}
+
+impl CachedCompression {
+    pub fn fairing(cached_path_endings: Vec<&'static str>) -> CachedCompression {
+      CachedCompression { cached_path_endings }
+    }
+}
+
+#[rocket::async_trait]
+impl Fairing for CachedCompression {
+    fn info(&self) -> Info {
+        Info {
+            name: "Cached response compression",
+            kind: Kind::Response,
+        }
+    }
+
+    async fn on_response<'r>(&self, request: &'r Request<'_>, response: &mut Response<'r>) {
+        let path = request.uri().path().to_string();
+        let cache_compressed_respones = self.cached_path_endings.iter().any(|s| path.ends_with(s));
+        let (accepts_gzip, accepts_br) = request
+            .headers()
+            .get("Accept-Encoding")
+            .flat_map(|accept| accept.split(','))
+            .map(|accept| accept.trim())
+            .fold((false, false), |(accepts_gzip, accepts_br), encoding| {
+                (
+                    accepts_gzip || encoding == "gzip",
+                    accepts_br || encoding == "br",
+                )
+            });
+
+        if cache_compressed_respones {
+            if let Some((cached_body, header)) = CACHED_FILES.lock().unwrap().get(&(path.clone(), accepts_gzip, accepts_br)) {
+                response.set_header(rocket::http::Header::new(
+                    "content-encoding",
+                    header.clone(),
+                ));
+                let body = cached_body.clone();
+                response.set_sized_body(body.len(), Cursor::new(body));
+                return;
+            }
+        }
+
+        super::CompressionUtils::compress_response(request, response, &EXCLUSIONS);
+
+        if !cache_compressed_respones {
+            return;
+        }
+
+        let mut compressed_body: Vec<u8> = vec![];
+        match response.body_mut().read_to_end(&mut compressed_body).await {
+            Err(_) => return,
+            _ => ()
+        }
+        response.set_sized_body(compressed_body.len(), Cursor::new(compressed_body.clone()));
+        let header = response.headers().get_one("content-encoding").unwrap().to_string();
+        CACHED_FILES.lock().unwrap().insert((path, accepts_gzip, accepts_br), (compressed_body, header));
     }
 }

--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -1,7 +1,9 @@
 use lazy_static::lazy_static;
-use rocket::fairing::{Fairing, Info, Kind};
-use rocket::http::hyper::header::CONTENT_ENCODING;
-use rocket::{http::MediaType, Request, Response};
+use rocket::{
+    fairing::{Fairing, Info, Kind},
+    http::{hyper::header::CONTENT_ENCODING, MediaType},
+    Request, Response,
+};
 use std::{collections::HashMap, io::Cursor, sync::Mutex};
 use tokio::io::AsyncReadExt;
 

--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -5,7 +5,7 @@ use rocket::{
     Request, Response,
 };
 use std::{collections::HashMap, io::Cursor, sync::Mutex};
-use tokio::io::AsyncReadExt;
+use rocket::tokio::io::AsyncReadExt;
 
 lazy_static! {
     static ref EXCLUSIONS: Vec<MediaType> = vec![
@@ -162,12 +162,8 @@ impl Fairing for CachedCompression {
             });
 
         if cache_compressed_responses {
-            if let Some((cached_body, header)) =
-                CACHED_FILES
-                    .lock()
-                    .unwrap()
-                    .get(&(path.clone(), accepts_gzip, accepts_br))
-            {
+            let guard = CACHED_FILES.lock().unwrap();
+            if let Some((cached_body, header)) = guard.get(&(path.clone(), accepts_gzip, accepts_br)) {
                 response.set_header(rocket::http::Header::new(
                     CONTENT_ENCODING.as_str(),
                     header.clone(),
@@ -175,6 +171,8 @@ impl Fairing for CachedCompression {
                 let body = cached_body.clone();
                 response.set_sized_body(body.len(), Cursor::new(body));
                 return;
+            } else {
+                drop(guard);
             }
         }
 

--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -148,7 +148,7 @@ impl Fairing for CachedCompression {
 
     async fn on_response<'r>(&self, request: &'r Request<'_>, response: &mut Response<'r>) {
         let path = request.uri().path().to_string();
-        let cache_compressed_respones = self.cached_path_endings.iter().any(|s| path.ends_with(s));
+        let cache_compressed_responses = self.cached_path_endings.iter().any(|s| path.ends_with(s));
         let (accepts_gzip, accepts_br) = request
             .headers()
             .get("Accept-Encoding")
@@ -161,7 +161,7 @@ impl Fairing for CachedCompression {
                 )
             });
 
-        if cache_compressed_respones {
+        if cache_compressed_responses {
             if let Some((cached_body, header)) =
                 CACHED_FILES
                     .lock()
@@ -180,7 +180,7 @@ impl Fairing for CachedCompression {
 
         super::CompressionUtils::compress_response(request, response, &EXCLUSIONS);
 
-        if !cache_compressed_respones {
+        if !cache_compressed_responses {
             return;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 mod fairing;
 mod responder;
 
-pub use self::{fairing::Compression, responder::Compress};
+pub use self::{fairing::{Compression, CachedCompression}, responder::Compress};
 
 use rocket::{
     http::{hyper::header::CONTENT_ENCODING, MediaType},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,21 @@ impl CompressionUtils {
         }
     }
 
+    /// Returns a tuple of the form (accepts_gzip, accepts_br).
+    fn accepted_algorithms(request: &Request<'_>) -> (bool, bool) {
+        request
+        .headers()
+        .get("Accept-Encoding")
+        .flat_map(|accept| accept.split(','))
+        .map(|accept| accept.trim())
+        .fold((false, false), |(accepts_gzip, accepts_br), encoding| {
+            (
+                accepts_gzip || encoding == "gzip",
+                accepts_br || encoding == "br",
+            )
+        })
+    }
+
     fn compress_response<'r>(
         request: &Request<'_>,
         response: &'_ mut Response<'r>,
@@ -120,17 +135,7 @@ impl CompressionUtils {
             return;
         }
 
-        let (accepts_gzip, accepts_br) = request
-            .headers()
-            .get("Accept-Encoding")
-            .flat_map(|accept| accept.split(','))
-            .map(|accept| accept.trim())
-            .fold((false, false), |(accepts_gzip, accepts_br), encoding| {
-                (
-                    accepts_gzip || encoding == "gzip",
-                    accepts_br || encoding == "br",
-                )
-            });
+        let (accepts_gzip, accepts_br) = Self::accepted_algorithms(request);
 
         if !accepts_gzip && !accepts_br {
             return;


### PR DESCRIPTION
# Motivation

I'm working on a side project called [Jonline](https://github.com/jonlatane/jonline) that serves up a compiled Flutter Web app with Rocket. The compiled JS and OTF files are fairly large (~3MB and 1.5MB respectively) and Brotli on "Best" is pretty slow. The compression time for these files was around 10s each.

The new `CachedCompression` fairing lets developers manually specify, like in the documented example, that the server should keep an in-memory cache of compressed OTF and compiled JS files. I found that this brought page load times from 20-30s for my Flutter app down to ~500ms, basically instant loads on my cheap DigitalOcean Kubernetes server running multiple instances of my app.

# Implementation Notes

I implemented this with specfication of the files whose compressed versions should be cached being done in Rust. I noticed the `EXCLUSIONS` thing in the current fairing mentioned some TOML configuration, but I'm not convinced that's actually working as documented; it looks to just pass the statically-coded exclusions 😕 But I'm not that familiar with Rocket TOML things.

So, if it would make more sense to implement the caching configuration in TOML than Rust, just tell me how! 🫡