### PR TITLE
Add async_compression::Level controls, default to Level::Default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocket_async_compression"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 description = "Response compression in both gzip and brotli formats for the Rocket webserver using the async-compression library"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add this to `Cargo.toml`:
 ```toml
 [dependencies]
 rocket = "0.5.0-rc.2"
-rocket_async_compression = "0.4.0"
+rocket_async_compression = "0.5.0"
 ```
 
 ## Usage

--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -124,14 +124,21 @@ impl Fairing for Compression {
 /// rocket::build()
 ///     // ...
 ///     .attach(CachedCompression {
-///       cached_paths: vec!["", "/", "/about", "/people", "/posts", "/events", "/groups"],
-///       cached_path_prefixes: vec!["/user/", "/g/", "/p/"],
-///       cached_path_suffixes: vec![".otf", "main.dart.js"],
-///       ..Default::default()
+///         cached_paths: vec![
+///             "".to_owned(),
+///             "/".to_owned(),
+///             "/about".to_owned(),
+///             "/people".to_owned(),
+///             "/posts".to_owned(),
+///             "/events".to_owned(),
+///             "/groups".to_owned(),
+///         ],
+///         cached_path_prefixes: vec!["/user/".to_owned(), "/g/".to_owned(), "/p/".to_owned()],
+///         cached_path_suffixes: vec![".otf".to_owned(), "main.dart.js".to_owned()],
+///         ..Default::default()
 ///     })
 ///     // ...
 ///     # ;
-///
 /// ```
 ///
 ///

--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -126,7 +126,8 @@ impl Fairing for Compression {
 ///     .attach(CachedCompression {
 ///       cached_paths: vec!["", "/", "/about", "/people", "/posts", "/events", "/groups"],
 ///       cached_path_prefixes: vec!["/user/", "/g/", "/p/"],
-///       cached_path_suffixes: vec![".otf", "main.dart.js"]
+///       cached_path_suffixes: vec![".otf", "main.dart.js"],
+///       ..Default::default()
 ///     })
 ///     // ...
 ///     # ;

--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -88,6 +88,25 @@ impl Compression {
     pub fn fairing() -> Compression {
         Compression(Level::Default)
     }
+
+    /// Returns a fairing that compresses outgoing requests with the specified
+    /// compression level.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    ///
+    /// use rocket_async_compression::{Compression, Level};
+    ///
+    /// rocket::build()
+    ///    // ...
+    ///    .attach(Compression::with_level(Level::Fastest))
+    ///    // ...
+    ///    # ;
+    /// ```
+    pub fn with_level(level: Level) -> Compression {
+        Compression(level)
+    }
 }
 
 #[rocket::async_trait]

--- a/src/fairing.rs
+++ b/src/fairing.rs
@@ -86,7 +86,7 @@ impl Compression {
     ///     # ;
     /// ```
     pub fn fairing() -> Compression {
-        Compression(Level::Best)
+        Compression(Level::Default)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub use self::{
     responder::Compress,
 };
 
+pub use async_compression::Level;
 use fairing::CachedEncoding;
 use rocket::{
     http::{hyper::header::CONTENT_ENCODING, MediaType},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,10 +131,19 @@ impl CompressionUtils {
     async fn compress_body<'r>(
         body: Body<'r>,
         encoding: CachedEncoding,
-        level: async_compression::Level
+        level: async_compression::Level,
     ) -> std::io::Result<Vec<u8>> {
         match encoding {
             CachedEncoding::Brotli => {
+                // The broli library used internally by `async-compression` has a default compression level of "best", or 11.  This
+                // is unsuitable for dynamic data and makes compression extremely slow.
+                //
+                // We set a compression level of 4 if the user requests default which matches the behavior of Nginx.
+                let level = match level {
+                    async_compression::Level::Default => async_compression::Level::Precise(4),
+                    other => other,
+                };
+
                 let mut compressor = async_compression::tokio::bufread::BrotliEncoder::with_quality(
                     rocket::tokio::io::BufReader::new(body),
                     level,
@@ -159,7 +168,7 @@ impl CompressionUtils {
         request: &Request<'_>,
         response: &'_ mut Response<'r>,
         exclusions: &[MediaType],
-        level: async_compression::Level
+        level: async_compression::Level,
     ) {
         if CompressionUtils::already_encoded(response) {
             return;

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -19,22 +19,26 @@ use super::CompressionUtils;
 /// use rocket_async_compression::Compress;
 ///
 /// # #[allow(unused_variables)]
-/// let response = Compress("Hi.");
+/// let response = Compress.default("Hi.");
 /// ```
 #[derive(Debug)]
-pub struct Compress<R>(pub R);
+pub struct Compress<R>(pub R, pub async_compression::Level);
 
-impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for Compress<R> {
-    #[inline(always)]
-    fn respond_to(self, request: &'r Request<'_>) -> response::Result<'o> {
-        CompressToLevel(self.0, async_compression::Level::Default).respond_to(request)
+impl<'r, 'o: 'r, R: Responder<'r, 'o>> Compress<R> {
+    pub fn default(r: R) -> Compress<R> {
+        Compress(r, async_compression::Level::Default)
+    }
+
+    pub fn best(r: R) -> Compress<R> {
+        Compress(r, async_compression::Level::Best)
+    }
+
+    pub fn fastest(r: R) -> Compress<R> {
+        Compress(r, async_compression::Level::Fastest)
     }
 }
 
-#[derive(Debug)]
-pub struct CompressToLevel<R>(pub R, pub async_compression::Level);
-
-impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for CompressToLevel<R> {
+impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for Compress<R> {
     #[inline(always)]
     fn respond_to(self, request: &'r Request<'_>) -> response::Result<'o> {
         let mut response = Response::build()

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -22,7 +22,7 @@ use super::CompressionUtils;
 /// let response = Compress("Hi.");
 /// ```
 #[derive(Debug)]
-pub struct Compress<R>(pub R);
+pub struct Compress<R>(pub R, pub async_compression::Level);
 
 impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for Compress<R> {
     #[inline(always)]
@@ -31,7 +31,7 @@ impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for Compress<R> {
             .merge(self.0.respond_to(request)?)
             .finalize();
 
-        CompressionUtils::compress_response(request, &mut response, &[]);
+        CompressionUtils::compress_response(request, &mut response, &[], self.1);
         Ok(response)
     }
 }

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -18,8 +18,7 @@ use super::CompressionUtils;
 /// ```rust
 /// use rocket_async_compression::Compress;
 ///
-/// # #[allow(unused_variables)]
-/// let response = Compress.default("Hi.");
+/// let response = Compress::default("Hi.");
 /// ```
 #[derive(Debug)]
 pub struct Compress<R>(pub R, pub async_compression::Level);

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -22,9 +22,19 @@ use super::CompressionUtils;
 /// let response = Compress("Hi.");
 /// ```
 #[derive(Debug)]
-pub struct Compress<R>(pub R, pub async_compression::Level);
+pub struct Compress<R>(pub R);
 
 impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for Compress<R> {
+    #[inline(always)]
+    fn respond_to(self, request: &'r Request<'_>) -> response::Result<'o> {
+        CompressToLevel(self.0, async_compression::Level::Default).respond_to(request)
+    }
+}
+
+#[derive(Debug)]
+pub struct CompressToLevel<R>(pub R, pub async_compression::Level);
+
+impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for CompressToLevel<R> {
     #[inline(always)]
     fn respond_to(self, request: &'r Request<'_>) -> response::Result<'o> {
         let mut response = Response::build()


### PR DESCRIPTION
This builds on https://github.com/Ameobea/rocket_async_compression/pull/8 slightly and adds `async_compression::Level` controls to `Compress` as well as the `Compression` and `CachedCompression` fairings. It also effectively switches all of the above to default to `Level::Default` instead of `Level::Best`, as I found its worst-case (first load) to average-case response times to be better for at least the CPUs of the servers I'm using. Happy to update the default either way, though I would argue making the default `Level::Default` has some clear merits 😄 

(I'd previously mentioned trying to do progressive caching in the background but the Rocket `Body` lifetime makes this problematic... This works well in the meantime though!)