### PR TITLE
Readme updates + added git repo in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.5.1"
 edition = "2021"
 repository = "https://github.com/Ameobea/rocket_async_compression"
 description = "Response compression in both gzip and brotli formats for the Rocket webserver using the `async-compression` library"
-license-file = "LICENSE"
+license = "MIT"
 keywords = ["rocket", "gzip", "brotli", "compression"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rocket_async_compression"
 version = "0.5.1"
 edition = "2021"
-
+repository = "https://github.com/Ameobea/rocket_async_compression"
 description = "Response compression in both gzip and brotli formats for the Rocket webserver using the `async-compression` library"
 license-file = "LICENSE"
 keywords = ["rocket", "gzip", "brotli", "compression"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Rocket Async Compression
 
-This library provides response compression in both gzip and brotli formats for the [Rocket](https://rocket.rs/) using the [`async-compression`](https://docs.rs/async-compression/0.3.8/async_compression/) library.
-
-It currently supports usage with Rocket `0.5.0-rc.2`. If you want to use a different version, you'll have to fork this library and change `Cargo.toml`.
+This library provides response compression in both gzip and brotli formats for [Rocket](https://rocket.rs/) using the [`async-compression`](https://docs.rs/async-compression) library.
 
 > I'd love to get this merged into Rocket itself eventually since I think it would be a very useful addition that I myself can barely live without in a webserver.
 
@@ -12,8 +10,8 @@ Add this to `Cargo.toml`:
 
 ```toml
 [dependencies]
-rocket = "0.5.0-rc.2"
-rocket_async_compression = "0.5.0"
+rocket = "0.5"
+rocket_async_compression = "0.5"
 ```
 
 ## Usage


### PR DESCRIPTION
- Readme: switch references of rocket 0.5-rc2 to rocket 0.5 series,
and fixed a typo
- Cargo.toml: added git repo for better source code discoverability on crates.io